### PR TITLE
Create wallet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ name = "uniffi_lipabusinesslib"
 uniffi = "0.20.0"
 thiserror = "1.0.36"
 log = "0.4.17"
+bdk = { version = "0.22.0", features = ["keys-bip39"] }
+rand = "0.8.5"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 oslog = "0.2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,8 @@
 #[derive(Debug, thiserror::Error)]
-pub enum WalletGenerationError {
-    #[error("Failed to generate wallet: {message}")]
-    Other { message: String },
+pub enum MnemonicGenerationError {
+    #[error("Failed to generate entropy: {message}")]
+    EntropyGeneration { message: String },
+
+    #[error("Failed to generate mnemonic from entropy: {message}")]
+    MnemonicFromEntropy { message: String },
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,3 +6,24 @@ pub enum MnemonicGenerationError {
     #[error("Failed to generate mnemonic from entropy: {message}")]
     MnemonicFromEntropy { message: String },
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyDerivationError {
+    #[error("Failed to parse provided mnemonic: {message}")]
+    MnemonicParsing { message: String },
+
+    #[error("Failed to turn Mnemonic into ExtendedKey: {message}")]
+    ExtendedKeyFromMnemonic { message: String },
+
+    #[error("Failed to turn ExtendedPrivKey into ExtendedKey: {message}")]
+    ExtendedKeyFromXPriv { message: String },
+
+    #[error("Failed to turn ExtendedKey into ExtendedPrivKey")]
+    XPrivFromExtendedKey,
+
+    #[error("Failed to parse derivation path: {message}")]
+    DerivationPathParse { message: String },
+
+    #[error("Failed to derive the provided path: {message}")]
+    Derivation { message: String },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ mod secrets;
 
 use crate::errors::{KeyDerivationError, MnemonicGenerationError};
 use crate::native_logger::init_native_logger_once;
-use crate::secrets::{derive_keys_for_caching, generate_mnemonic, KeyPair, LipaKeys};
+use crate::secrets::{derive_keys, generate_mnemonic, KeyPair, LipaKeys};
 
 use bdk::bitcoin::Network;
 use log::Level as LogLevel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,54 @@
 mod errors;
 mod native_logger;
 
-use crate::errors::WalletGenerationError;
+use crate::errors::MnemonicGenerationError;
 use crate::native_logger::init_native_logger_once;
+use bdk::keys::bip39::Mnemonic;
 
 use log::Level as LogLevel;
+use rand::rngs::OsRng;
+use rand::RngCore;
 
-pub struct Wallet {
-    private_key: Vec<u8>,
+fn generate_random_bytes() -> Result<[u8; 32], MnemonicGenerationError> {
+    let mut bytes = [0u8; 32];
+    OsRng
+        .try_fill_bytes(&mut bytes)
+        .map_err(|e| MnemonicGenerationError::EntropyGeneration {
+            message: e.to_string(),
+        })?;
+    Ok(bytes)
 }
 
-pub fn generate_wallet() -> Result<Wallet, WalletGenerationError> {
-    Ok(Wallet {
-        private_key: vec![1, 2, 3],
-    })
+pub fn generate_mnemonic() -> Result<Vec<String>, MnemonicGenerationError> {
+    let entropy = generate_random_bytes()?;
+    let mnemonic = Mnemonic::from_entropy(&entropy).map_err(|e| {
+        MnemonicGenerationError::MnemonicFromEntropy {
+            message: e.to_string(),
+        }
+    })?;
+
+    let mnemonic: Vec<String> = mnemonic.word_iter().map(|s| s.to_string()).collect();
+
+    Ok(mnemonic)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_mnemonic_generation() {
+        let mnemonic_string = generate_mnemonic().unwrap();
+        assert_eq!(mnemonic_string.len(), 24);
+    }
+
+    #[test]
+    fn test_mnemonic_code_decode() {
+        let mnemonic_string = generate_mnemonic().unwrap();
+        let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).unwrap();
+        assert_eq!(mnemonic_string.join(" "), mnemonic.to_string());
+    }
 }
 
 include!(concat!(env!("OUT_DIR"), "/lipabusinesslib.uniffi.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,54 +1,12 @@
 mod errors;
 mod native_logger;
+mod secrets;
 
-use crate::errors::MnemonicGenerationError;
+use crate::errors::{KeyDerivationError, MnemonicGenerationError};
 use crate::native_logger::init_native_logger_once;
-use bdk::keys::bip39::Mnemonic;
+use crate::secrets::{derive_keys_for_caching, generate_mnemonic, KeyPair, LipaKeys};
 
+use bdk::bitcoin::Network;
 use log::Level as LogLevel;
-use rand::rngs::OsRng;
-use rand::RngCore;
-
-fn generate_random_bytes() -> Result<[u8; 32], MnemonicGenerationError> {
-    let mut bytes = [0u8; 32];
-    OsRng
-        .try_fill_bytes(&mut bytes)
-        .map_err(|e| MnemonicGenerationError::EntropyGeneration {
-            message: e.to_string(),
-        })?;
-    Ok(bytes)
-}
-
-pub fn generate_mnemonic() -> Result<Vec<String>, MnemonicGenerationError> {
-    let entropy = generate_random_bytes()?;
-    let mnemonic = Mnemonic::from_entropy(&entropy).map_err(|e| {
-        MnemonicGenerationError::MnemonicFromEntropy {
-            message: e.to_string(),
-        }
-    })?;
-
-    let mnemonic: Vec<String> = mnemonic.word_iter().map(|s| s.to_string()).collect();
-
-    Ok(mnemonic)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn test_mnemonic_generation() {
-        let mnemonic_string = generate_mnemonic().unwrap();
-        assert_eq!(mnemonic_string.len(), 24);
-    }
-
-    #[test]
-    fn test_mnemonic_code_decode() {
-        let mnemonic_string = generate_mnemonic().unwrap();
-        let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).unwrap();
-        assert_eq!(mnemonic_string.join(" "), mnemonic.to_string());
-    }
-}
 
 include!(concat!(env!("OUT_DIR"), "/lipabusinesslib.uniffi.rs"));

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -1,3 +1,10 @@
+enum Network {
+    "Bitcoin",
+    "Testnet",
+    "Signet",
+    "Regtest",
+};
+
 enum LogLevel {
     "Error",
     "Warn",
@@ -12,8 +19,31 @@ enum MnemonicGenerationError {
     "MnemonicFromEntropy",
 };
 
+[Error]
+enum KeyDerivationError {
+    "MnemonicParsing",
+    "ExtendedKeyFromMnemonic",
+    "ExtendedKeyFromXPriv",
+    "XPrivFromExtendedKey",
+    "DerivationPathParse",
+    "Derivation",
+};
+
+dictionary KeyPair {
+    sequence<u8> secret_key;
+    sequence<u8> public_key;
+};
+
+dictionary LipaKeys {
+    KeyPair auth_keypair;
+    string master_xpriv;
+    string account_xpub;
+};
+
 namespace lipabusinesslib {
     void init_native_logger_once(LogLevel min_level);
     [Throws=MnemonicGenerationError]
     sequence<string> generate_mnemonic();
+    [Throws=KeyDerivationError]
+    LipaKeys derive_keys_for_caching(Network network, sequence<string> mnemonic_string);
 };

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -45,5 +45,5 @@ namespace lipabusinesslib {
     [Throws=MnemonicGenerationError]
     sequence<string> generate_mnemonic();
     [Throws=KeyDerivationError]
-    LipaKeys derive_keys_for_caching(Network network, sequence<string> mnemonic_string);
+    LipaKeys derive_keys(Network network, sequence<string> mnemonic_string);
 };

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -7,16 +7,13 @@ enum LogLevel {
 };
 
 [Error]
-enum WalletGenerationError {
-    "Other",
-};
-
-dictionary Wallet {
-    sequence<u8> private_key;
+enum MnemonicGenerationError {
+    "EntropyGeneration",
+    "MnemonicFromEntropy",
 };
 
 namespace lipabusinesslib {
     void init_native_logger_once(LogLevel min_level);
-    [Throws=WalletGenerationError]
-    Wallet generate_wallet();
+    [Throws=MnemonicGenerationError]
+    sequence<string> generate_mnemonic();
 };

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,0 +1,246 @@
+use crate::errors::{KeyDerivationError, MnemonicGenerationError};
+use bdk::bitcoin::secp256k1::PublicKey;
+use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey};
+use bdk::bitcoin::Network;
+use bdk::keys::bip39::Mnemonic;
+use bdk::keys::{DerivableKey, ExtendedKey};
+use bdk::miniscript::ToPublicKey;
+use rand::rngs::OsRng;
+use rand::RngCore;
+use std::str::FromStr;
+
+const BACKEND_AUTH_DERIVATION_PATH: &str = "m/76738065h/0h/0";
+const ACCOUNT_DERIVATION_PATH: &str = "m/84h/1h/0h";
+
+pub fn generate_mnemonic() -> Result<Vec<String>, MnemonicGenerationError> {
+    let entropy = generate_random_bytes()?;
+    let mnemonic = Mnemonic::from_entropy(&entropy).map_err(|e| {
+        MnemonicGenerationError::MnemonicFromEntropy {
+            message: e.to_string(),
+        }
+    })?;
+
+    let mnemonic: Vec<String> = mnemonic.word_iter().map(|s| s.to_string()).collect();
+
+    Ok(mnemonic)
+}
+
+fn generate_random_bytes() -> Result<[u8; 32], MnemonicGenerationError> {
+    let mut bytes = [0u8; 32];
+    OsRng
+        .try_fill_bytes(&mut bytes)
+        .map_err(|e| MnemonicGenerationError::EntropyGeneration {
+            message: e.to_string(),
+        })?;
+    Ok(bytes)
+}
+
+pub struct KeyPair {
+    pub secret_key: Vec<u8>,
+    pub public_key: Vec<u8>,
+}
+
+pub struct LipaKeys {
+    pub auth_keypair: KeyPair,
+    pub master_xpriv: String,
+    pub account_xpub: String,
+}
+
+pub fn derive_keys_for_caching(
+    network: Network,
+    mnemonic_string: Vec<String>,
+) -> Result<LipaKeys, KeyDerivationError> {
+    let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).map_err(|e| {
+        KeyDerivationError::MnemonicParsing {
+            message: e.to_string(),
+        }
+    })?;
+
+    let auth_keypair = derive_auth_keypair(network, mnemonic.clone())?;
+
+    let master_xpriv = get_master_xpriv(network, mnemonic.clone())?.to_string();
+
+    let account_xpub = derive_account_xpub(network, mnemonic)?;
+
+    Ok(LipaKeys {
+        auth_keypair,
+        master_xpriv,
+        account_xpub,
+    })
+}
+
+fn derive_auth_keypair(
+    network: Network,
+    mnemonic: Mnemonic,
+) -> Result<KeyPair, KeyDerivationError> {
+    let secp256k1 = bdk::bitcoin::secp256k1::Secp256k1::new();
+
+    let master_xpriv = get_master_xpriv(network, mnemonic)?;
+
+    let lipa_purpose_path =
+        DerivationPath::from_str(BACKEND_AUTH_DERIVATION_PATH).map_err(|e| {
+            KeyDerivationError::DerivationPathParse {
+                message: e.to_string(),
+            }
+        })?;
+    let auth_xpriv = master_xpriv
+        .derive_priv(&secp256k1, &lipa_purpose_path)
+        .map_err(|e| KeyDerivationError::Derivation {
+            message: e.to_string(),
+        })?;
+
+    let auth_priv_key = auth_xpriv.private_key.secret_bytes().to_vec();
+
+    let auth_pub_key = PublicKey::from_secret_key(&secp256k1, &auth_xpriv.private_key)
+        .to_public_key()
+        .to_bytes();
+
+    Ok(KeyPair {
+        secret_key: auth_priv_key,
+        public_key: auth_pub_key,
+    })
+}
+
+fn get_master_xpriv(
+    network: Network,
+    mnemonic: Mnemonic,
+) -> Result<ExtendedPrivKey, KeyDerivationError> {
+    let master_extended_key: ExtendedKey =
+        mnemonic
+            .into_extended_key()
+            .map_err(|e| KeyDerivationError::ExtendedKeyFromMnemonic {
+                message: e.to_string(),
+            })?;
+    let master_xpriv = match master_extended_key.into_xprv(network) {
+        None => return Err(KeyDerivationError::XPrivFromExtendedKey),
+        Some(xpriv) => xpriv,
+    };
+    Ok(master_xpriv)
+}
+
+fn derive_account_xpub(network: Network, mnemonic: Mnemonic) -> Result<String, KeyDerivationError> {
+    let secp256k1 = bdk::bitcoin::secp256k1::Secp256k1::new();
+
+    let master_xpriv = get_master_xpriv(network, mnemonic)?;
+
+    let wallet_account_path = DerivationPath::from_str(ACCOUNT_DERIVATION_PATH).map_err(|e| {
+        KeyDerivationError::DerivationPathParse {
+            message: e.to_string(),
+        }
+    })?;
+
+    let account_xpriv = master_xpriv
+        .derive_priv(&secp256k1, &wallet_account_path)
+        .map_err(|e| KeyDerivationError::Derivation {
+            message: e.to_string(),
+        })?;
+    let account_xkey: ExtendedKey = account_xpriv.into_extended_key().map_err(|e| {
+        KeyDerivationError::ExtendedKeyFromXPriv {
+            message: e.to_string(),
+        }
+    })?;
+
+    let account_xpub = account_xkey.into_xpub(network, &secp256k1);
+
+    Ok(account_xpub.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bdk::bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use bdk::bitcoin::util::bip32::ExtendedPubKey;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_mnemonic_generation() {
+        let mnemonic_string = generate_mnemonic().unwrap();
+        assert_eq!(mnemonic_string.len(), 24);
+    }
+
+    #[test]
+    fn test_mnemonic_code_decode() {
+        let mnemonic_string = generate_mnemonic().unwrap();
+        let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).unwrap();
+        assert_eq!(mnemonic_string.join(" "), mnemonic.to_string());
+    }
+
+    #[test]
+    fn test_keys_code_decode() {
+        let mnemonic_string = generate_mnemonic().unwrap();
+        let keys = derive_keys_for_caching(Network::Testnet, mnemonic_string).unwrap();
+
+        let auth_priv_key = SecretKey::from_slice(keys.auth_keypair.secret_key.as_slice()).unwrap();
+        assert_eq!(
+            keys.auth_keypair.secret_key,
+            auth_priv_key.secret_bytes().to_vec()
+        );
+
+        let auth_pub_key = PublicKey::from_slice(keys.auth_keypair.public_key.as_slice()).unwrap();
+        assert_eq!(
+            keys.auth_keypair.public_key,
+            auth_pub_key.to_public_key().to_bytes()
+        );
+
+        let master_xpriv = ExtendedPrivKey::from_str(keys.master_xpriv.as_str()).unwrap();
+        assert_eq!(keys.master_xpriv, master_xpriv.to_string());
+
+        let account_xpub = ExtendedPubKey::from_str(keys.account_xpub.as_str()).unwrap();
+        assert_eq!(keys.account_xpub, account_xpub.to_string());
+    }
+
+    #[test]
+    fn test_auth_keys_match() {
+        let mnemonic_string = generate_mnemonic().unwrap();
+        let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).unwrap();
+
+        let keypair = derive_auth_keypair(Network::Testnet, mnemonic).unwrap();
+
+        let public_key_from_secret_key = PublicKey::from_secret_key(
+            &Secp256k1::new(),
+            &SecretKey::from_slice(keypair.secret_key.as_slice()).unwrap(),
+        );
+
+        assert_eq!(
+            keypair.public_key,
+            public_key_from_secret_key.to_public_key().to_bytes()
+        );
+    }
+
+    #[test]
+    fn test_master_and_account_derivation_match() {
+        let secp256k1 = bdk::bitcoin::secp256k1::Secp256k1::new();
+
+        let mnemonic_string = generate_mnemonic().unwrap();
+
+        let keys = derive_keys_for_caching(Network::Testnet, mnemonic_string).unwrap();
+
+        let master_xpriv = ExtendedPrivKey::from_str(keys.master_xpriv.as_str()).unwrap();
+        let account_xpub = ExtendedPubKey::from_str(keys.account_xpub.as_str()).unwrap();
+
+        // `account_xpub` should be the xpub of `master_xpriv` at path "m/84h/1h/0h"
+        // Deriving from the master the public key at "m/84h/1h/0h/0/0" must be equivalent to
+        // deriving from the account the public key at "m/0/0"
+
+        let path_from_master =
+            DerivationPath::from_str(format!("{}{}", ACCOUNT_DERIVATION_PATH, "/0/0").as_str())
+                .unwrap();
+        let path_from_account = DerivationPath::from_str("m/0/0").unwrap();
+
+        let target_xkey_from_master: ExtendedKey = master_xpriv
+            .derive_priv(&secp256k1, &path_from_master)
+            .unwrap()
+            .into_extended_key()
+            .unwrap();
+        let target_pubkey_from_master = target_xkey_from_master
+            .into_xpub(Network::Testnet, &secp256k1)
+            .public_key;
+
+        let target_pubkey_from_account = account_xpub
+            .derive_pub(&secp256k1, &path_from_account)
+            .unwrap()
+            .public_key;
+
+        assert_eq!(target_pubkey_from_account, target_pubkey_from_master);
+    }
+}


### PR DESCRIPTION
Wallet creation is here implemented in 2 functions. 

- `generate_mnemonic()` should be called to generate a new 24-word mnemonic
- `derive_keys_for_caching()` should be called on a mnemonic so that useful keys can be cached and don't have to be derived every time. This is for performance reasons and also security reasons. For example, by caching the account `xpub` we avoid loading private keys into memory when we just want to check the on-chain balance.