### PR TITLE
Implement `get_balance()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 /bindings
 
+.bdk-database
+
 # Added by cargo
 /target
 /Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.17"
 bdk = { version = "0.22.0", features = ["keys-bip39"] }
 rand = "0.8.5"
 secp256k1 = { version = "0.22.1", features = ["bitcoin_hashes", "global-context"] }
+sled = "0.34.7"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 oslog = "0.2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,12 @@ pub enum WalletError {
 
     #[error("Failed to get balance from bdk::Wallet instance: {message}")]
     GetBalance { message: String },
+
+    #[error("Failed to open database for bdk::Wallet: {message}")]
+    OpenDatabase { message: String },
+
+    #[error("Failed to open database tree for bdk::Wallet: {message}")]
+    OpenDatabaseTree { message: String },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,6 +26,30 @@ pub enum KeyDerivationError {
 
     #[error("Failed to derive the provided path: {message}")]
     Derivation { message: String },
+
+    #[error("Failed to get a DescriptorKey from a ExtendedPrivKey: {message}")]
+    DescriptorKeyFromXPriv { message: String },
+
+    #[error("Failed to get a DescriptorPublicKey from a DescriptorSecretKey: {message}")]
+    DescPubKeyFromDescSecretKey { message: String },
+
+    #[error("Failed to get a DescriptorSecretKey from a DescriptorKey")]
+    DescSecretKeyFromDescKey,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WalletError {
+    #[error("Failed to create a client to get blockchain data: {message}")]
+    ChainBackendClient { message: String },
+
+    #[error("Failed to create a bdk::Wallet instance: {message}")]
+    BdkWallet { message: String },
+
+    #[error("Failed to sync with the blockchain: {message}")]
+    ChainSync { message: String },
+
+    #[error("Failed to get balance from bdk::Wallet instance: {message}")]
+    GetBalance { message: String },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, thiserror::Error)]
-pub enum MnemonicGenerationError {
+pub enum KeyGenerationError {
     #[error("Failed to generate entropy: {message}")]
     EntropyGeneration { message: String },
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,8 +9,20 @@ pub enum KeyGenerationError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum KeyDerivationError {
-    #[error("Failed to parse provided mnemonic: {message}")]
-    MnemonicParsing { message: String },
+    #[error("Failed to derive the provided path: {message}")]
+    Derivation { message: String },
+
+    #[error("Failed to parse derivation path: {message}")]
+    DerivationPathParse { message: String },
+
+    #[error("Failed to get a DescriptorKey from a ExtendedPrivKey: {message}")]
+    DescKeyFromXPriv { message: String },
+
+    #[error("Failed to get a DescriptorPublicKey from a DescriptorSecretKey: {message}")]
+    DescPubKeyFromDescSecretKey { message: String },
+
+    #[error("Failed to get a DescriptorSecretKey from a DescriptorKey")]
+    DescSecretKeyFromDescKey,
 
     #[error("Failed to turn Mnemonic into ExtendedKey: {message}")]
     ExtendedKeyFromMnemonic { message: String },
@@ -18,32 +30,20 @@ pub enum KeyDerivationError {
     #[error("Failed to turn ExtendedPrivKey into ExtendedKey: {message}")]
     ExtendedKeyFromXPriv { message: String },
 
+    #[error("Failed to parse provided mnemonic: {message}")]
+    MnemonicParsing { message: String },
+
     #[error("Failed to turn ExtendedKey into ExtendedPrivKey")]
     XPrivFromExtendedKey,
-
-    #[error("Failed to parse derivation path: {message}")]
-    DerivationPathParse { message: String },
-
-    #[error("Failed to derive the provided path: {message}")]
-    Derivation { message: String },
-
-    #[error("Failed to get a DescriptorKey from a ExtendedPrivKey: {message}")]
-    DescriptorKeyFromXPriv { message: String },
-
-    #[error("Failed to get a DescriptorPublicKey from a DescriptorSecretKey: {message}")]
-    DescPubKeyFromDescSecretKey { message: String },
-
-    #[error("Failed to get a DescriptorSecretKey from a DescriptorKey")]
-    DescSecretKeyFromDescKey,
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum WalletError {
-    #[error("Failed to create a client to get blockchain data: {message}")]
-    ChainBackendClient { message: String },
-
     #[error("Failed to create a bdk::Wallet instance: {message}")]
     BdkWallet { message: String },
+
+    #[error("Failed to create a client to get blockchain data: {message}")]
+    ChainBackendClient { message: String },
 
     #[error("Failed to sync with the blockchain: {message}")]
     ChainSync { message: String },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,16 @@ mod errors;
 mod native_logger;
 mod secrets;
 mod signing;
+mod wallet;
 
-use crate::errors::{KeyDerivationError, MnemonicGenerationError, SigningError};
+use crate::errors::{KeyDerivationError, MnemonicGenerationError, SigningError, WalletError};
 use crate::native_logger::init_native_logger_once;
-use crate::secrets::{derive_keys, generate_mnemonic, KeyPair, LipaKeys};
+use crate::secrets::{derive_keys, generate_mnemonic, Descriptors, KeyPair, LipaKeys};
 use crate::signing::sign_message;
+use crate::wallet::{Config, Wallet};
 
 use bdk::bitcoin::Network;
+use bdk::Balance;
 use log::Level as LogLevel;
 
 include!(concat!(env!("OUT_DIR"), "/lipabusinesslib.uniffi.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use crate::secrets::{
     derive_keys, generate_keypair, generate_mnemonic, Descriptors, KeyPair, LipaKeys,
 };
 use crate::signing::sign_message;
-use crate::wallet::{Config, Wallet};
+pub use crate::wallet::{Config, Wallet};
 
 use bdk::bitcoin::Network;
 use bdk::Balance;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@ mod secrets;
 mod signing;
 mod wallet;
 
-use crate::errors::{KeyDerivationError, MnemonicGenerationError, SigningError, WalletError};
+use crate::errors::{KeyDerivationError, KeyGenerationError, SigningError, WalletError};
 use crate::native_logger::init_native_logger_once;
-use crate::secrets::{derive_keys, generate_mnemonic, Descriptors, KeyPair, LipaKeys};
+use crate::secrets::{
+    derive_keys, generate_keypair, generate_mnemonic, Descriptors, KeyPair, LipaKeys,
+};
 use crate::signing::sign_message;
 use crate::wallet::{Config, Wallet};
 

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -14,7 +14,7 @@ enum LogLevel {
 };
 
 [Error]
-enum MnemonicGenerationError {
+enum KeyGenerationError {
     "EntropyGeneration",
     "MnemonicFromEntropy",
 };
@@ -82,10 +82,12 @@ interface Wallet {
 
 namespace lipabusinesslib {
     void init_native_logger_once(LogLevel min_level);
-    [Throws=MnemonicGenerationError]
+    [Throws=KeyGenerationError]
     sequence<string> generate_mnemonic();
     [Throws=KeyDerivationError]
     LipaKeys derive_keys(Network network, sequence<string> mnemonic_string);
     [Throws=SigningError]
     string sign_message(string message, string secret_key);
+    [Throws=KeyGenerationError]
+    KeyPair generate_keypair();
 };

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -38,6 +38,8 @@ enum WalletError {
     "ChainBackendClient",
     "ChainSync",
     "GetBalance",
+    "OpenDatabase",
+    "OpenDatabaseTree",
 };
 
 [Error]
@@ -63,6 +65,7 @@ dictionary LipaKeys {
 
 dictionary Config {
     string electrum_url;
+    string wallet_db_path;
     Network network;
     string watch_descriptor;
 };

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -27,6 +27,17 @@ enum KeyDerivationError {
     "XPrivFromExtendedKey",
     "DerivationPathParse",
     "Derivation",
+    "DescriptorKeyFromXPriv",
+    "DescPubKeyFromDescSecretKey",
+    "DescSecretKeyFromDescKey",
+};
+
+[Error]
+enum WalletError {
+    "ChainBackendClient",
+    "BdkWallet",
+    "ChainSync",
+    "GetBalance",
 };
 
 [Error]
@@ -40,10 +51,33 @@ dictionary KeyPair {
     string public_key;
 };
 
+dictionary Descriptors {
+    string spend_descriptor;
+    string watch_descriptor;
+};
+
 dictionary LipaKeys {
     KeyPair auth_keypair;
-    string master_xpriv;
-    string account_xpub;
+    Descriptors wallet_descriptors;
+};
+
+dictionary Config {
+    string electrum_url;
+    Network network;
+};
+
+dictionary Balance {
+    u64 confirmed;
+    u64 trusted_pending;
+    u64 untrusted_pending;
+    u64 immature;
+};
+
+interface Wallet {
+    [Throws=WalletError]
+    constructor(Config config);
+    [Throws=WalletError]
+    Balance get_balance(string watch_descriptor);
 };
 
 namespace lipabusinesslib {

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -21,21 +21,21 @@ enum KeyGenerationError {
 
 [Error]
 enum KeyDerivationError {
-    "MnemonicParsing",
-    "ExtendedKeyFromMnemonic",
-    "ExtendedKeyFromXPriv",
-    "XPrivFromExtendedKey",
-    "DerivationPathParse",
     "Derivation",
-    "DescriptorKeyFromXPriv",
+    "DerivationPathParse",
+    "DescKeyFromXPriv",
     "DescPubKeyFromDescSecretKey",
     "DescSecretKeyFromDescKey",
+    "ExtendedKeyFromMnemonic",
+    "ExtendedKeyFromXPriv",
+    "MnemonicParsing",
+    "XPrivFromExtendedKey",
 };
 
 [Error]
 enum WalletError {
-    "ChainBackendClient",
     "BdkWallet",
+    "ChainBackendClient",
     "ChainSync",
     "GetBalance",
 };

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -81,7 +81,7 @@ interface Wallet {
     [Throws=WalletError]
     constructor(Config config);
     [Throws=WalletError]
-    Balance get_balance();
+    Balance sync_balance();
 };
 
 namespace lipabusinesslib {

--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -64,6 +64,7 @@ dictionary LipaKeys {
 dictionary Config {
     string electrum_url;
     Network network;
+    string watch_descriptor;
 };
 
 dictionary Balance {
@@ -77,7 +78,7 @@ interface Wallet {
     [Throws=WalletError]
     constructor(Config config);
     [Throws=WalletError]
-    Balance get_balance(string watch_descriptor);
+    Balance get_balance();
 };
 
 namespace lipabusinesslib {

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -13,7 +13,10 @@ use secp256k1::hashes::hex::ToHex;
 use secp256k1::SECP256K1;
 use std::str::FromStr;
 
-const BACKEND_AUTH_DERIVATION_PATH: &str = "m/76738065'/0'/0";
+// In the near future we want to migrate to the following keys for backend auth
+//const BACKEND_AUTH_DERIVATION_PATH: &str = "m/76738065'/0'/0";
+// For now, we use the master key pair
+const BACKEND_AUTH_DERIVATION_PATH: &str = "m";
 const ACCOUNT_DERIVATION_PATH_MAINNET: &str = "m/84'/0'/0'";
 const ACCOUNT_DERIVATION_PATH_TESTNET: &str = "m/84'/1'/0'";
 
@@ -214,7 +217,11 @@ pub mod test {
     const MNEMONIC_STR: &str = "between angry ketchup hill admit attitude echo wisdom still barrel coral obscure home museum trick grow magic eagle school tilt loop actress equal law";
     const SPEND_DESCRIPTOR: &str = "wpkh([aed2a027]tprv8ZgxMBicQKsPeT4bcpTNiHtBXqHRRPh4qMkWP4PahRJCGLd5A32RYUif9PJ8GMChWPB6yFFNGybZRGBFcsb9v9YifukeysfDAHDTzxRrtbi/84'/1'/0'/0/*)";
     const WATCH_DESCRIPTOR: &str = "wpkh([aed2a027/84'/1'/0']tpubDCvyR4gGk5U6r1Q1HMQtgZYMD3a9bVyt7Tv9BWgcBCQsff4aqR7arUGPTMaUbVwaH8TeaK924GJr9nHyGPBtqSCD8BCjMnJb1qZFjK4ACfL/0/*)";
-    const AUTH_PUB_KEY: &str = "02549b15801b155d32ca3931665361b1d2997ee531859b2d48cebbc2ccf21aac96";
+
+    // The following corresponds to path "m/76738065'/0'/0"
+    //const AUTH_PUB_KEY: &str = "02549b15801b155d32ca3931665361b1d2997ee531859b2d48cebbc2ccf21aac96";
+    // For now we'll use the master key pair
+    const AUTH_PUB_KEY: &str = "0365704b042bdf2a8bf19714902242f9275ce7b0e2438a35dbb25133c49d1c8ef2";
 
     fn mnemonic_str_to_vec(mnemonic_str: &str) -> Vec<String> {
         mnemonic_str.split(' ').map(|s| s.to_string()).collect()

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,4 +1,4 @@
-use crate::errors::{KeyDerivationError, MnemonicGenerationError};
+use crate::errors::{KeyDerivationError, KeyGenerationError};
 use bdk::bitcoin::secp256k1::PublicKey;
 use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, KeySource};
 use bdk::bitcoin::Network;
@@ -20,24 +20,23 @@ const BACKEND_AUTH_DERIVATION_PATH: &str = "m";
 const ACCOUNT_DERIVATION_PATH_MAINNET: &str = "m/84'/0'/0'";
 const ACCOUNT_DERIVATION_PATH_TESTNET: &str = "m/84'/1'/0'";
 
-pub fn generate_mnemonic() -> Result<Vec<String>, MnemonicGenerationError> {
+pub fn generate_mnemonic() -> Result<Vec<String>, KeyGenerationError> {
     let entropy = generate_random_bytes()?;
-    let mnemonic = Mnemonic::from_entropy(&entropy).map_err(|e| {
-        MnemonicGenerationError::MnemonicFromEntropy {
+    let mnemonic =
+        Mnemonic::from_entropy(&entropy).map_err(|e| KeyGenerationError::MnemonicFromEntropy {
             message: e.to_string(),
-        }
-    })?;
+        })?;
 
     let mnemonic: Vec<String> = mnemonic.word_iter().map(|s| s.to_string()).collect();
 
     Ok(mnemonic)
 }
 
-fn generate_random_bytes() -> Result<[u8; 32], MnemonicGenerationError> {
+fn generate_random_bytes() -> Result<[u8; 32], KeyGenerationError> {
     let mut bytes = [0u8; 32];
     OsRng
         .try_fill_bytes(&mut bytes)
-        .map_err(|e| MnemonicGenerationError::EntropyGeneration {
+        .map_err(|e| KeyGenerationError::EntropyGeneration {
             message: e.to_string(),
         })?;
     Ok(bytes)
@@ -205,6 +204,23 @@ fn key_to_wpkh_descriptor(key: &str) -> String {
     desc
 }
 
+pub fn generate_keypair() -> Result<KeyPair, KeyGenerationError> {
+    let secp256k1 = bdk::bitcoin::secp256k1::Secp256k1::new();
+
+    let mut rng = bdk::bitcoin::secp256k1::rand::rngs::OsRng::new().map_err(|e| {
+        KeyGenerationError::EntropyGeneration {
+            message: e.to_string(),
+        }
+    })?;
+
+    let (secret_key, public_key) = secp256k1.generate_keypair(&mut rng);
+
+    Ok(KeyPair {
+        secret_key: secret_key.secret_bytes().to_hex(),
+        public_key: public_key.serialize().to_hex(),
+    })
+}
+
 #[cfg(test)]
 pub mod test {
     use super::*;
@@ -289,15 +305,7 @@ pub mod test {
         );
     }
 
-    #[test]
-    fn test_auth_keys_match() {
-        let mnemonic_string = mnemonic_str_to_vec(MNEMONIC_STR);
-        let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).unwrap();
-
-        let master_xpriv = get_master_xpriv(NETWORK, mnemonic).unwrap();
-
-        let keypair = derive_auth_keypair(master_xpriv).unwrap();
-
+    fn check_keys_match(keypair: KeyPair) {
         let public_key_from_secret_key = PublicKey::from_secret_key(
             SECP256K1,
             &SecretKey::from_slice(Vec::from_hex(&keypair.secret_key).unwrap().as_slice()).unwrap(),
@@ -310,5 +318,24 @@ pub mod test {
                 .to_bytes()
                 .to_hex()
         );
+    }
+
+    #[test]
+    fn test_auth_keys_match() {
+        let mnemonic_string = mnemonic_str_to_vec(MNEMONIC_STR);
+        let mnemonic = Mnemonic::from_str(mnemonic_string.join(" ").as_str()).unwrap();
+
+        let master_xpriv = get_master_xpriv(NETWORK, mnemonic).unwrap();
+
+        let keypair = derive_auth_keypair(master_xpriv).unwrap();
+
+        check_keys_match(keypair);
+    }
+
+    #[test]
+    fn test_generate_keypair() {
+        let keypair = generate_keypair().unwrap();
+
+        check_keys_match(keypair);
     }
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,9 +1,11 @@
 use crate::errors::{KeyDerivationError, MnemonicGenerationError};
 use bdk::bitcoin::secp256k1::PublicKey;
-use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey};
+use bdk::bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, KeySource};
 use bdk::bitcoin::Network;
+use bdk::descriptor::Segwitv0;
 use bdk::keys::bip39::Mnemonic;
-use bdk::keys::{DerivableKey, ExtendedKey};
+use bdk::keys::DescriptorKey::Secret;
+use bdk::keys::{DerivableKey, DescriptorKey, ExtendedKey};
 use bdk::miniscript::ToPublicKey;
 use rand::rngs::OsRng;
 use rand::RngCore;
@@ -12,8 +14,8 @@ use secp256k1::SECP256K1;
 use std::str::FromStr;
 
 const BACKEND_AUTH_DERIVATION_PATH: &str = "m/76738065'/0'/0";
-const ACCOUNT_DERIVATION_PATH_MAINNET: &str = "m/84'/1'/0h";
-const ACCOUNT_DERIVATION_PATH_TESTNET: &str = "m/84'/1'/1h";
+const ACCOUNT_DERIVATION_PATH_MAINNET: &str = "m/84'/0'/0'";
+const ACCOUNT_DERIVATION_PATH_TESTNET: &str = "m/84'/1'/0'";
 
 pub fn generate_mnemonic() -> Result<Vec<String>, MnemonicGenerationError> {
     let entropy = generate_random_bytes()?;
@@ -43,10 +45,14 @@ pub struct KeyPair {
     pub public_key: String,
 }
 
+pub struct Descriptors {
+    pub spend_descriptor: String,
+    pub watch_descriptor: String,
+}
+
 pub struct LipaKeys {
     pub auth_keypair: KeyPair,
-    pub master_xpriv: String,
-    pub account_xpub: String,
+    pub wallet_descriptors: Descriptors,
 }
 
 pub fn derive_keys(
@@ -62,13 +68,25 @@ pub fn derive_keys(
     let master_xpriv = get_master_xpriv(network, mnemonic)?;
 
     let auth_keypair = derive_auth_keypair(master_xpriv)?;
-
-    let account_xpub = derive_account_xpub(network, master_xpriv)?;
+    let spend_descriptor = build_descriptor(
+        master_xpriv,
+        "m",
+        format!("{}{}", get_account_derivation_path(network), "/0").as_str(),
+        false,
+    )?;
+    let watch_descriptor = build_descriptor(
+        master_xpriv,
+        get_account_derivation_path(network),
+        "m/0",
+        true,
+    )?;
 
     Ok(LipaKeys {
         auth_keypair,
-        master_xpriv: master_xpriv.to_string(),
-        account_xpub: account_xpub.to_string(),
+        wallet_descriptors: Descriptors {
+            spend_descriptor,
+            watch_descriptor,
+        },
     })
 }
 
@@ -114,31 +132,58 @@ fn get_master_xpriv(
     Ok(master_xpriv)
 }
 
-fn derive_account_xpub(
-    network: Network,
+fn build_descriptor(
     master_xpriv: ExtendedPrivKey,
-) -> Result<ExtendedPubKey, KeyDerivationError> {
-    let account_path_str = get_account_derivation_path(network);
-    let wallet_account_path = DerivationPath::from_str(account_path_str).map_err(|e| {
-        KeyDerivationError::DerivationPathParse {
-            message: e.to_string(),
-        }
-    })?;
+    extended_key_derivation_path: &str,
+    descriptor_derivation_path: &str,
+    public: bool,
+) -> Result<String, KeyDerivationError> {
+    let secp256k1 = bdk::bitcoin::secp256k1::Secp256k1::new();
 
-    let account_xpriv = master_xpriv
-        .derive_priv(SECP256K1, &wallet_account_path)
+    let extended_key_derivation_path = DerivationPath::from_str(extended_key_derivation_path)
+        .map_err(|e| KeyDerivationError::DerivationPathParse {
+            message: e.to_string(),
+        })?;
+    let descriptor_derivation_path =
+        DerivationPath::from_str(descriptor_derivation_path).map_err(|e| {
+            KeyDerivationError::DerivationPathParse {
+                message: e.to_string(),
+            }
+        })?;
+
+    let derived_xpriv = master_xpriv
+        .derive_priv(&secp256k1, &extended_key_derivation_path)
         .map_err(|e| KeyDerivationError::Derivation {
             message: e.to_string(),
         })?;
-    let account_xkey: ExtendedKey = account_xpriv.into_extended_key().map_err(|e| {
-        KeyDerivationError::ExtendedKeyFromXPriv {
+
+    let origin: KeySource = (
+        master_xpriv.fingerprint(&secp256k1),
+        extended_key_derivation_path,
+    );
+
+    let derived_xpriv_desc_key: DescriptorKey<Segwitv0> = derived_xpriv
+        .into_descriptor_key(Some(origin), descriptor_derivation_path)
+        .map_err(|e| KeyDerivationError::DescriptorKeyFromXPriv {
             message: e.to_string(),
-        }
-    })?;
+        })?;
 
-    let account_xpub = account_xkey.into_xpub(network, SECP256K1);
-
-    Ok(account_xpub)
+    if let Secret(desc_seckey, _, _) = derived_xpriv_desc_key {
+        let desc_key = match public {
+            true => {
+                let desc_pubkey = desc_seckey.as_public(&secp256k1).map_err(|e| {
+                    KeyDerivationError::DescPubKeyFromDescSecretKey {
+                        message: e.to_string(),
+                    }
+                })?;
+                desc_pubkey.to_string()
+            }
+            false => desc_seckey.to_string(),
+        };
+        Ok(key_to_wpkh_descriptor(&desc_key))
+    } else {
+        Err(KeyDerivationError::DescSecretKeyFromDescKey)
+    }
 }
 
 fn get_account_derivation_path(network: Network) -> &'static str {
@@ -150,19 +195,25 @@ fn get_account_derivation_path(network: Network) -> &'static str {
     }
 }
 
+fn key_to_wpkh_descriptor(key: &str) -> String {
+    let mut desc = "wpkh(".to_string();
+    desc.push_str(key);
+    desc.push(')');
+    desc
+}
+
 #[cfg(test)]
 pub mod test {
     use super::*;
     use bdk::bitcoin::secp256k1::{PublicKey, SecretKey};
-    use bdk::bitcoin::util::bip32::ExtendedPubKey;
     use secp256k1::hashes::hex::FromHex;
     use std::str::FromStr;
 
     // Values used for testing were obtained from https://iancoleman.io/bip39
     const NETWORK: Network = Network::Testnet;
     const MNEMONIC_STR: &str = "between angry ketchup hill admit attitude echo wisdom still barrel coral obscure home museum trick grow magic eagle school tilt loop actress equal law";
-    const MASTER_XPRIV: &str = "tprv8ZgxMBicQKsPeT4bcpTNiHtBXqHRRPh4qMkWP4PahRJCGLd5A32RYUif9PJ8GMChWPB6yFFNGybZRGBFcsb9v9YifukeysfDAHDTzxRrtbi";
-    const ACCOUNT_XPUB: &str = "tpubDCvyR4gGk5U6uqmiEPmJnYodvoGabDj9mN4mG7gTshTWC8aELcNALdtcCntH6Ro6dMv9NnevkCPsCpZ1hWifx2Mt83a1Wiy5GcYhuFd9ocq";
+    const SPEND_DESCRIPTOR: &str = "wpkh([aed2a027]tprv8ZgxMBicQKsPeT4bcpTNiHtBXqHRRPh4qMkWP4PahRJCGLd5A32RYUif9PJ8GMChWPB6yFFNGybZRGBFcsb9v9YifukeysfDAHDTzxRrtbi/84'/1'/0'/0/*)";
+    const WATCH_DESCRIPTOR: &str = "wpkh([aed2a027/84'/1'/0']tpubDCvyR4gGk5U6r1Q1HMQtgZYMD3a9bVyt7Tv9BWgcBCQsff4aqR7arUGPTMaUbVwaH8TeaK924GJr9nHyGPBtqSCD8BCjMnJb1qZFjK4ACfL/0/*)";
     const AUTH_PUB_KEY: &str = "02549b15801b155d32ca3931665361b1d2997ee531859b2d48cebbc2ccf21aac96";
 
     fn mnemonic_str_to_vec(mnemonic_str: &str) -> Vec<String> {
@@ -188,16 +239,22 @@ pub mod test {
 
         let keys = derive_keys(NETWORK, mnemonic_string).unwrap();
 
-        assert_eq!(keys.master_xpriv, MASTER_XPRIV.to_string());
-        assert_eq!(keys.account_xpub, ACCOUNT_XPUB.to_string());
-        assert_eq!(keys.auth_keypair.public_key, AUTH_PUB_KEY);
+        assert_eq!(
+            keys.wallet_descriptors.spend_descriptor,
+            SPEND_DESCRIPTOR.to_string()
+        );
+        assert_eq!(
+            keys.wallet_descriptors.watch_descriptor,
+            WATCH_DESCRIPTOR.to_string()
+        );
+        assert_eq!(keys.auth_keypair.public_key, AUTH_PUB_KEY.to_string());
 
         // No need to check that the auth secret_key is correct because here we check the auth
         // public key and in `test_auth_keys_match()` we check that the keys match.
     }
 
     #[test]
-    fn test_keys_encode_decode() {
+    fn test_auth_keys_encode_decode() {
         let mnemonic_string = mnemonic_str_to_vec(MNEMONIC_STR);
 
         let keys = derive_keys(NETWORK, mnemonic_string).unwrap();
@@ -223,12 +280,6 @@ pub mod test {
             keys.auth_keypair.public_key,
             auth_pub_key.to_public_key().to_bytes().to_hex()
         );
-
-        let master_xpriv = ExtendedPrivKey::from_str(keys.master_xpriv.as_str()).unwrap();
-        assert_eq!(keys.master_xpriv, master_xpriv.to_string());
-
-        let account_xpub = ExtendedPubKey::from_str(keys.account_xpub.as_str()).unwrap();
-        assert_eq!(keys.account_xpub, account_xpub.to_string());
     }
 
     #[test]
@@ -252,40 +303,5 @@ pub mod test {
                 .to_bytes()
                 .to_hex()
         );
-    }
-
-    #[test]
-    fn test_master_and_account_derivation_match() {
-        let mnemonic_string = mnemonic_str_to_vec(MNEMONIC_STR);
-
-        let keys = derive_keys(NETWORK, mnemonic_string).unwrap();
-
-        let master_xpriv = ExtendedPrivKey::from_str(keys.master_xpriv.as_str()).unwrap();
-        let account_xpub = ExtendedPubKey::from_str(keys.account_xpub.as_str()).unwrap();
-
-        // `account_xpub` should be the xpub of `master_xpriv` at path "m/84'/1'/0'"
-        // Deriving from the master the public key at "m/84'/1'/0'/0/0" must be equivalent to
-        // deriving from the account the public key at "m/0/0"
-
-        let account_path_str = get_account_derivation_path(NETWORK);
-        let path_from_master =
-            DerivationPath::from_str(format!("{}{}", account_path_str, "/0/0").as_str()).unwrap();
-        let path_from_account = DerivationPath::from_str("m/0/0").unwrap();
-
-        let target_xkey_from_master: ExtendedKey = master_xpriv
-            .derive_priv(SECP256K1, &path_from_master)
-            .unwrap()
-            .into_extended_key()
-            .unwrap();
-        let target_pubkey_from_master = target_xkey_from_master
-            .into_xpub(NETWORK, SECP256K1)
-            .public_key;
-
-        let target_pubkey_from_account = account_xpub
-            .derive_pub(SECP256K1, &path_from_account)
-            .unwrap()
-            .public_key;
-
-        assert_eq!(target_pubkey_from_account, target_pubkey_from_master);
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,0 +1,101 @@
+use crate::errors::WalletError;
+use bdk::bitcoin::Network;
+use bdk::blockchain::ElectrumBlockchain;
+use bdk::database::MemoryDatabase;
+use bdk::electrum_client::Client;
+use bdk::{Balance, SyncOptions};
+
+pub struct Config {
+    pub electrum_url: String,
+    pub network: Network,
+}
+
+pub struct Wallet {
+    config: Config,
+    blockchain: ElectrumBlockchain,
+}
+
+impl Wallet {
+    pub fn new(config: Config) -> Result<Self, WalletError> {
+        let client =
+            Client::new(&config.electrum_url).map_err(|e| WalletError::ChainBackendClient {
+                message: e.to_string(),
+            })?;
+        let blockchain = ElectrumBlockchain::from(client);
+
+        Ok(Self { config, blockchain })
+    }
+
+    pub fn get_balance(&self, watch_descriptor: String) -> Result<Balance, WalletError> {
+        let wallet = bdk::Wallet::new(
+            &watch_descriptor,
+            None,
+            self.config.network,
+            MemoryDatabase::default(),
+        )
+        .map_err(|e| WalletError::BdkWallet {
+            message: e.to_string(),
+        })?;
+
+        wallet
+            .sync(&self.blockchain, SyncOptions::default())
+            .map_err(|e| WalletError::ChainSync {
+                message: e.to_string(),
+            })?;
+
+        let balance = wallet.get_balance().map_err(|e| WalletError::GetBalance {
+            message: e.to_string(),
+        })?;
+
+        Ok(balance)
+    }
+
+    // Not needed for now
+    /*pub fn get_address(&self, watch_descriptor: String) -> Result<String, WalletError> {
+        let wallet = bdk::Wallet::new(
+            &watch_descriptor,
+            None,
+            self.config.network,
+            MemoryDatabase::default(),
+        )
+        .map_err(|e| WalletError::BdkWallet {
+            message: e.to_string(),
+        })?;
+
+        wallet
+            .sync(&self.blockchain, SyncOptions::default())
+            .map_err(|e| WalletError::ChainSync {
+                message: e.to_string(),
+            })?;
+
+        let address = wallet.get_address(AddressIndex::LastUnused).unwrap().address;
+
+        Ok(address.to_string())
+    }*/
+}
+
+// The following test is commented out because it relies on an external service but
+// it should work if uncommented.
+// TODO: change test blockchain backend to a local instance
+#[cfg(test)]
+mod test {
+
+    //use crate::{Config, Wallet};
+    //use bdk::bitcoin::Network;
+
+    //const WATCH_DESCRIPTOR: &str = "wpkh([aed2a027/84'/1'/0']tpubDCvyR4gGk5U6r1Q1HMQtgZYMD3a9bVyt7Tv9BWgcBCQsff4aqR7arUGPTMaUbVwaH8TeaK924GJr9nHyGPBtqSCD8BCjMnJb1qZFjK4ACfL/0/*)";
+
+    /*
+    #[test]
+    fn test_get_balance() {
+        let wallet = Wallet::new(Config {
+            electrum_url: "ssl://electrum.blockstream.info:60002".to_string(),
+            network: Network::Testnet,
+        })
+        .unwrap();
+
+        let balance = wallet.get_balance(WATCH_DESCRIPTOR.to_string()).unwrap();
+
+        assert_eq!(balance.confirmed, 88009);
+    }*/
+}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -46,7 +46,7 @@ impl Wallet {
         Ok(Self { blockchain, wallet })
     }
 
-    pub fn get_balance(&self) -> Result<Balance, WalletError> {
+    pub fn sync_balance(&self) -> Result<Balance, WalletError> {
         let wallet = self.wallet.lock().unwrap();
 
         wallet

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -74,30 +74,3 @@ impl Wallet {
         Ok(address.to_string())
     }*/
 }
-
-// The following test is commented out because it relies on an external service but
-// it should work if uncommented.
-// TODO: change test blockchain backend to a local instance
-#[cfg(test)]
-mod test {
-
-    //use crate::{Config, Wallet};
-    //use bdk::bitcoin::Network;
-
-    //const WATCH_DESCRIPTOR: &str = "wpkh([aed2a027/84'/1'/0']tpubDCvyR4gGk5U6r1Q1HMQtgZYMD3a9bVyt7Tv9BWgcBCQsff4aqR7arUGPTMaUbVwaH8TeaK924GJr9nHyGPBtqSCD8BCjMnJb1qZFjK4ACfL/0/*)";
-
-    /*
-    #[test]
-    fn test_get_balance() {
-        let wallet = Wallet::new(Config {
-            electrum_url: "ssl://electrum.blockstream.info:60002".to_string(),
-            network: Network::Testnet,
-            watch_descriptor: WATCH_DESCRIPTOR.to_string(),
-        })
-        .unwrap();
-
-        let balance = wallet.get_balance().unwrap();
-
-        assert_eq!(balance.confirmed, 88009);
-    }*/
-}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -8,6 +8,7 @@ use bdk::{Balance, SyncOptions};
 pub struct Config {
     pub electrum_url: String,
     pub network: Network,
+    pub watch_descriptor: String,
 }
 
 pub struct Wallet {
@@ -26,9 +27,9 @@ impl Wallet {
         Ok(Self { config, blockchain })
     }
 
-    pub fn get_balance(&self, watch_descriptor: String) -> Result<Balance, WalletError> {
+    pub fn get_balance(&self) -> Result<Balance, WalletError> {
         let wallet = bdk::Wallet::new(
-            &watch_descriptor,
+            &self.config.watch_descriptor,
             None,
             self.config.network,
             MemoryDatabase::default(),
@@ -91,10 +92,11 @@ mod test {
         let wallet = Wallet::new(Config {
             electrum_url: "ssl://electrum.blockstream.info:60002".to_string(),
             network: Network::Testnet,
+            watch_descriptor: WATCH_DESCRIPTOR.to_string(),
         })
         .unwrap();
 
-        let balance = wallet.get_balance(WATCH_DESCRIPTOR.to_string()).unwrap();
+        let balance = wallet.get_balance().unwrap();
 
         assert_eq!(balance.confirmed, 88009);
     }*/

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,18 @@
+use bdk::bitcoin::Network;
+use uniffi_lipabusinesslib::{Config, Wallet};
+
+const WATCH_DESCRIPTOR: &str = "wpkh([aed2a027/84'/1'/0']tpubDCvyR4gGk5U6r1Q1HMQtgZYMD3a9bVyt7Tv9BWgcBCQsff4aqR7arUGPTMaUbVwaH8TeaK924GJr9nHyGPBtqSCD8BCjMnJb1qZFjK4ACfL/0/*)";
+
+#[test]
+fn test_get_balance_testnet_electrum() {
+    let wallet = Wallet::new(Config {
+        electrum_url: "ssl://electrum.blockstream.info:60002".to_string(),
+        network: Network::Testnet,
+        watch_descriptor: WATCH_DESCRIPTOR.to_string(),
+    })
+    .unwrap();
+
+    let balance = wallet.get_balance().unwrap();
+
+    assert_eq!(balance.confirmed, 88009);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13,7 +13,7 @@ fn test_get_balance_testnet_electrum() {
     })
     .unwrap();
 
-    let balance = wallet.get_balance().unwrap();
+    let balance = wallet.sync_balance().unwrap();
 
     assert_eq!(balance.confirmed, 88009);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -7,6 +7,7 @@ const WATCH_DESCRIPTOR: &str = "wpkh([aed2a027/84'/1'/0']tpubDCvyR4gGk5U6r1Q1HMQ
 fn test_get_balance_testnet_electrum() {
     let wallet = Wallet::new(Config {
         electrum_url: "ssl://electrum.blockstream.info:60002".to_string(),
+        wallet_db_path: ".bdk-database".to_string(),
         network: Network::Testnet,
         watch_descriptor: WATCH_DESCRIPTOR.to_string(),
     })


### PR DESCRIPTION
As BDK is descriptor-based, I found it useful to give the client descriptors instead of extended keys.

Electrum is used to get chain data. I experimented with the BDK's Esplora client, but it was ~6x slower 🤔 

The method `get_balance()` can be tested by uncommenting the included test in `wallet.rs`. It is commented because it relies on an external electrum server. A `TODO` was added for creating tests that rely on a local electrum instance.

It's worth noting that this implementation is not very efficient but should be good enough for now. It's inefficient mainly for 2 reasons:
- It's using a `MemoryDatabase` on `Wallet`. This means that no blockchain info is cached across restarts. I opted for this because otherwise, we need to implement our own [database](https://docs.rs/bdk/latest/bdk/database/index.html), which doesn't seem trivial.
- It's not even taking advantage of the `MemoryDatabase`. Because of UniFFI, we cannot store a `bdk::Wallet<MemoryDatabase>` in `Wallet`. This is because UniFFI forces that all Object structs must be `Sync + Send`, and it happens that `RefCell<MemoryDatabase>`, a field of `bdk::Wallet`, is not `Sync`. 

I experimented to see how much we lose by, in practice, not using any database. For a very simple scenario (a single UTXO in the wallet), I got 850 ms with caching and 1350 ms without caching. Given that it's in the same order of magnitude, I'd suggest using the less efficient approach first. Later, we can implement our own `Database` if we see that it's worth it.