### PR TITLE
Remove implicit sync() from wallet methods

### DIFF
--- a/src/lipabusinesslib.udl
+++ b/src/lipabusinesslib.udl
@@ -110,13 +110,16 @@ interface Wallet {
     [Throws=LipaError]
     constructor(Config config);
 
-    // Syncs with Electrum to update the local database
+    // Syncs the local database with Electrum
     [Throws=LipaError]
     void sync();
 
-    // Syncs with Electrum to get the current balance of the wallet.
+    // Get the current balance of the wallet.
+    //
+    // The balance is obtained from the local database. To have the balance be up-to-date, the method `sync()` should be
+    // called  beforehand.
     [Throws=LipaError]
-    Balance sync_balance();
+    Balance get_balance();
 
     // Get an unused P2WPKH address from the local wallet
     [Throws=LipaError]
@@ -140,6 +143,9 @@ interface Wallet {
     TxDetails sign_and_broadcast_tx(sequence<u8> tx_blob, string spend_descriptor);
 
     // Returns the status of a tx given its tx id.
+    //
+    // The status is obtained from the local database. To have the status be up-to-date, the method `sync()` should be
+    // called  beforehand.
     [Throws=LipaError]
     TxStatus get_tx_status(string txid);
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -88,9 +88,7 @@ impl Wallet {
         Ok(Self { blockchain, wallet })
     }
 
-    pub fn sync_balance(&self) -> LipaResult<Balance> {
-        self.sync()?;
-
+    pub fn get_balance(&self) -> LipaResult<Balance> {
         let wallet = self.wallet.lock().unwrap();
 
         let balance = wallet
@@ -172,8 +170,6 @@ impl Wallet {
         address: Address,
         confirm_in_blocks: u32,
     ) -> LipaResult<Tx> {
-        self.sync()?;
-
         let fee_rate = self
             .blockchain
             .estimate_fee(confirm_in_blocks as usize)
@@ -257,8 +253,6 @@ impl Wallet {
     pub fn get_tx_status(&self, txid: String) -> LipaResult<TxStatus> {
         let txid = Txid::from_str(&txid).map_to_invalid_input("Invalid tx id")?;
 
-        self.sync()?;
-
         let wallet = self.wallet.lock().unwrap();
         Self::get_tx_status_internal(&wallet, txid)
     }
@@ -282,8 +276,6 @@ impl Wallet {
     }
 
     pub fn get_addr(&self) -> LipaResult<String> {
-        self.sync()?;
-
         let wallet = self.wallet.lock().unwrap();
 
         let address = wallet
@@ -320,8 +312,6 @@ impl Wallet {
             ));
         }
         drop(wallet); // To release the lock.
-
-        self.sync()?;
 
         let fee_rate = self
             .blockchain


### PR DESCRIPTION
The `sync()` on `sign_and_broadcast_tx()` was kept because otherwise we can't easily return the TxDetails of the broadcasted tx.