### PR TITLE
Add periodic GitHub actions check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - main
       - develop
   pull_request:
+  schedule:
+    - cron: '21 2 * * 1-5' # every weekday at 2:21 AM UTC
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -10,6 +10,8 @@ on:
       - main
       - develop
   pull_request:
+  schedule:
+    - cron: '21 2 * * 1-5' # every weekday at 2:21 AM UTC
 
 jobs:
   security-audit:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,8 @@ on:
       - main
       - develop
   pull_request:
+  schedule:
+    - cron: '21 2 * * 1-5' # every weekday at 2:21 AM UTC
 
 jobs:
   integration:


### PR DESCRIPTION
Check every day at 2:21 AM UTC for environmental changes such as new Rust version released, security vulnerabilities found, interfaces of remote services changed (-> integration tests), etc.

This becomes particularly relevant if we don't actively work on the project for a long time.
