### PR TITLE
Prepare for purging develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,3 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
-    target-branch: develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
   schedule:
     - cron: '21 2 * * 1-5' # every weekday at 2:21 AM UTC

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
   schedule:
     - cron: '21 2 * * 1-5' # every weekday at 2:21 AM UTC

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
   schedule:
     - cron: '21 2 * * 1-5' # every weekday at 2:21 AM UTC


### PR DESCRIPTION
Setup GitHub Actions and Dependabot such that the `develop` branch can be removed subsequently